### PR TITLE
Refactored build to remove obsolete resources file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 
-**Update: 2017-08-11**
-The build process for this repo has been changed from a Delivery cookbook to a NodeJS implementation.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/azure-marketplace-ui-chef-extension/_apis/build/status/chef-partners.azure-marketplace-ui?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/azure-marketplace-ui-chef-extension/_build/latest?definitionId=58&branchName=master)
 
 # Azure Marketplace UI Extension
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: 1.4$(Rev.r)
+name: 1.4$(Rev:.r)
 
 stages:
 - stage: Build
@@ -38,7 +38,7 @@ stages:
       inputs:
         command: custom
         verbose: false
-        customerCommand: run script:package
+        customCommand: run script:package
 
     - task: CopyFiles@2
       displayName: Copy Zip files to artefact directory

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,54 @@
+name: 1.4$(Rev.r)
+
+stages:
+- stage: Build
+  displayName: Build Stage
+
+
+  jobs:
+  - job: Build
+    displayName: Create UI Extension Package
+    pool:
+      name: Hosted
+
+    steps:
+
+    - task: Npm@1
+      displayName: Install Modules
+      inputs:
+        command: install
+        verbose: false
+
+    - task: Npm@1
+      displayName: Compile Build Scripts
+      inputs:
+        command: custom
+        verbose: false
+        customCommand: run compile:scripts
+
+    - task: Npm@1
+      displayName: Gather up extension files
+      inputs:
+        command: custom
+        verbose: false
+        customCommand: run script:build
+
+    - task: Npm@1
+      displayName: Create Zip files
+      inputs:
+        command: custom
+        verbose: false
+        customerCommand: run script:package
+
+    - task: CopyFiles@2
+      displayName: Copy Zip files to artefact directory
+      inputs:
+        SourceFolder: $(build.sourcesdirectory)/build
+        Contents: '*.zip'
+        TargetFolder: $(build.artifactstagingdirectory)
+
+    - task: PublishBuildArtifacts@1
+      displayName: "Publish Artifact: Upload zip files"
+      inputs:
+        PathToPublish: $(build.artifactstagingdirectory)
+        ArtifactName: zipfiles

--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@types/node": "^8.0.20",
+    "@types/node": "^12.6",
     "change-case": "^3.0.1",
     "colors": "^1.1.2",
-    "command-line-args": "^4.0.7",
-    "fs-extra": "^4.0.1",
-    "mustache": "^2.3.0",
+    "command-line-args": "^5.1",
+    "folder-zipper": "^1.0.0",
+    "fs-extra": "^8.1",
+    "mustache": "^3.0",
     "rimraf": "^2.6.1",
     "sprintf-js": "^1.1.1",
-    "typescript": "^2.4.2",
-    "zip-folder": "^1.0.0"
+    "typescript": "^3.5"
   }
 }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -43,9 +43,6 @@ if (!fs.existsSync(options["directory"])) {
 let template = {
     "ui_definition": fs.readFileSync(path.join(config["paths"]["basedir"], "templates", "UIDefinition.json"), "utf-8"),
     "manifest": fs.readFileSync(path.join(config["paths"]["basedir"], "templates", "Manifest.json"), "utf-8"),
-    "strings": {
-        "resources": fs.readFileSync(path.join(config["paths"]["basedir"], "templates", "Strings", "Resources.resjson"), "utf-8")
-    },
     "artifacts": {
         "maintemplate": fs.readFileSync(path.join(config["paths"]["basedir"], "templates", "Artifacts", "MainTemplate.json"), "utf-8"),
         "createuidefinition": fs.readFileSync(path.join(config["paths"]["basedir"], "templates", "Artifacts", "CreateUIDefinition.json"), "utf-8")
@@ -76,7 +73,7 @@ for (let model of options["models"]) {
             fs.mkdirSync(type_dir)
         }
 
-        let version = common.getVersion(options["version"], type)
+        let version = options["version"]; // common.getVersion(options["version"], type)
         console.log(colors.green("    Type: %s (%s)"), type, version)
 
         // Iterate around the platforms
@@ -113,20 +110,11 @@ for (let model of options["models"]) {
                 suffix: config["models"][model]["suffix"],
                 version: version,
                 categories: JSON.stringify(config["platforms"][platform]["categories"]),
-                filters: JSON.stringify(config["platforms"][platform]["filters"][type])
+                filters: JSON.stringify(config["platforms"][platform]["filters"][type]),
+                extra: type == "beta" ? " Beta" : ""
             }
             let manifest = Mustache.render(template["manifest"], replacements)
             fs.writeFileSync(path.join(platform_dir, "Manifest.json"), manifest)
-
-            // Strings resource file
-            console.log(colors.yellow("        Strings/Resources.resjson"))
-            replacements = {
-                platform: changeCase.titleCase(platform),
-                version: version,
-                extra: type == "beta" ? " Beta" : ""
-            }
-            let strings_resources = Mustache.render(template["strings"]["resources"], replacements)
-            fs.writeFileSync(path.join(platform_dir, "Strings", "Resources.resjson"), strings_resources)
 
             // MainTemplate file
             console.log(colors.yellow("        Artifacts/MainTemplate.json"))

--- a/scripts/common.ts
+++ b/scripts/common.ts
@@ -19,6 +19,11 @@ export function getConfig() {
         basedir: basedir
     }
 
+    // Set the version based on environment variable
+    if (process.env.BUILD_BUILDNUMBER ) {
+        config["version"] = process.env.BUILD_BUILDNUMBER;
+    }
+
     // Return the configuration
     return config
 }

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -53,10 +53,11 @@ for (let model of options["models"]) {
             let filename_parts = [
                 platform,
                 config["models"][model]["suffix"],
+                process.env.BUILD_SOURCEBRANCHNAME ? process.env.BUILD_SOURCEBRANCHNAME : "local",
                 version,
                 type == "beta" ? "-beta" : ""
             ]
-            let zip_filename = path.join(options["directory"], vsprintf("azure-marketplace-ui-%s%s.%s%s.zip", filename_parts))
+            let zip_filename = path.join(options["directory"], vsprintf("azure-marketplace-ui-%s%s-%s.%s%s.zip", filename_parts))
             
             zipper(platform_dir, zip_filename)
                 .then(() => {

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -5,7 +5,7 @@ import * as common from "./common.js"
 import * as commandLineArgs from "command-line-args"
 import * as colors from "colors/safe"
 import * as path from "path"
-import * as zipFolder from "zip-folder"
+import * as zipper from "folder-zipper"
 import {vsprintf} from "sprintf-js"
 
 // Read in the configuration file
@@ -41,7 +41,7 @@ for (let model of options["models"]) {
         // Create the directory for the type
         let type_dir = path.join(model_dir, type)
 
-        let version = common.getVersion(options["version"], type)
+        let version = options["version"]; //common.getVersion(options["version"], type)
 
         // iterate around the platforms
         for (let platform in config["platforms"]) {
@@ -58,13 +58,13 @@ for (let model of options["models"]) {
             ]
             let zip_filename = path.join(options["directory"], vsprintf("azure-marketplace-ui-%s%s.%s%s.zip", filename_parts))
             
-            zipFolder(platform_dir, zip_filename, function(err) {
-                if (err) {
-                    console.log(colors.red("  FAILED"), err)
-                } else {
+            zipper(platform_dir, zip_filename)
+                .then(() => {
                     console.log(colors.green("  SUCCESS: %s"), zip_filename)
-                }
-            })
+                })
+                .catch(err => {
+                    console.log(colors.red("  FAILED"), err)
+                })
         }
 
     }

--- a/templates/Manifest.json
+++ b/templates/Manifest.json
@@ -3,12 +3,12 @@
   "name": "chef-client-{{ platform }}{{ suffix }}",
   "publisher": "chef-software",
   "version": "{{ version }}",
-  "displayName": "ms-resource:displayName",
-  "publisherDisplayName": "ms-resource:publisherDisplayName",
-  "publisherLegalName": "ms-resource:publisherDisplayName",
-  "summary": "ms-resource:summary",
-  "longSummary": "ms-resource:description",
-  "description": "ms-resource:description",
+  "displayName": "Chef Extension ({{ version }}{{ extra }} {{ platform }})",
+  "publisherDisplayName": "Chef Software Inc.",
+  "publisherLegalName": "Chef Software Inc.",
+  "summary": "Install the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
+  "longSummary": "Install the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
+  "description": "Install the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
   "uiDefinition": {
     "path": "UiDefinition.json"
   },
@@ -38,15 +38,15 @@
   "links": [
     {
       "displayName": "Chef Software",
-      "uri": "ms-resource:siteurl"
+      "uri": "https://chef.io"
     },
     {
       "displayName": "Learn Chef",
-      "uri": "ms-resource:learnchef"
+      "uri": "https://learnchef.com"
     },
     {
       "displayName": "Extension Source",
-      "uri": "ms-resource:extsource"
+      "uri": "https://github.com/chef-partners/azure-chef-extension"
     }
   ],
   "categories": {{{ categories }}},

--- a/templates/Manifest.json
+++ b/templates/Manifest.json
@@ -3,12 +3,12 @@
   "name": "chef-client-{{ platform }}{{ suffix }}",
   "publisher": "chef-software",
   "version": "{{ version }}",
-  "displayName": "Chef Extension - {{ platform }}",
+  "displayName": "Chef VM extension for {{ platform }}",
   "publisherDisplayName": "Chef Software Inc.",
   "publisherLegalName": "Chef Software Inc.",
-  "summary": "Install the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
-  "longSummary": "{{ version }}{{ extra }}\r\nInstall the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
-  "description": "{{ version }}{{ extra }}\r\nInstall the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
+  "summary": "Install the Chef Infra Client on your Virtual Machine and bootstrap to your Chef Server",
+  "longSummary": "{{ version }}{{ extra }}\r\nInstall the Chef Infra Client on your Virtual Machine and bootstrap to your Chef Server",
+  "description": "{{ version }}{{ extra }}\r\nInstall the Chef Infra Client on your Virtual Machine and bootstrap to your Chef Server",
   "uiDefinition": {
     "path": "UiDefinition.json"
   },

--- a/templates/Manifest.json
+++ b/templates/Manifest.json
@@ -3,12 +3,12 @@
   "name": "chef-client-{{ platform }}{{ suffix }}",
   "publisher": "chef-software",
   "version": "{{ version }}",
-  "displayName": "Chef Extension ({{ version }}{{ extra }} {{ platform }})",
+  "displayName": "Chef Extension - {{ platform }}",
   "publisherDisplayName": "Chef Software Inc.",
   "publisherLegalName": "Chef Software Inc.",
   "summary": "Install the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
-  "longSummary": "Install the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
-  "description": "Install the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
+  "longSummary": "{{ version }}{{ extra }}\r\nInstall the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
+  "description": "{{ version }}{{ extra }}\r\nInstall the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
   "uiDefinition": {
     "path": "UiDefinition.json"
   },
@@ -42,7 +42,7 @@
     },
     {
       "displayName": "Learn Chef",
-      "uri": "https://learnchef.com"
+      "uri": "https://learn.chef.io"
     },
     {
       "displayName": "Extension Source",

--- a/templates/Manifest.json
+++ b/templates/Manifest.json
@@ -3,7 +3,7 @@
   "name": "chef-client-{{ platform }}{{ suffix }}",
   "publisher": "chef-software",
   "version": "{{ version }}",
-  "displayName": "Chef VM extension for {{ platform }}",
+  "displayName": "Chef VM Extension for {{ platform }}",
   "publisherDisplayName": "Chef Software Inc.",
   "publisherLegalName": "Chef Software Inc.",
   "summary": "Install the Chef Infra Client on your Virtual Machine and bootstrap to your Chef Server",

--- a/templates/Strings/Resources.resjson
+++ b/templates/Strings/Resources.resjson
@@ -1,9 +1,0 @@
-{
-  "displayName": "Chef Extension ({{ version }}{{ extra }} {{ platform }})",
-  "publisherDisplayName": "Chef Software Inc.",
-  "summary": "Install the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
-  "description": "Install the Chef Client on your Virtual Machine and bootstrap to your Chef Server",
-  "siteurl": "https://chef.io",
-  "learnchef": "https://learnchef.com",
-  "extsource": "https://github.com/chef-partners/azure-chef-extension"
-}


### PR DESCRIPTION
After discovering that the `.resjson` file format is no longer supported, this branch removes this file.

Other things updates in this branch:

- AzDo pipeline added
- Zip filenames include Build Number and branch name
- Updated NPM modules to avoid vulnerabilities
- Changed zip library as one being used had not been updated and was using unsafe version of `lodash`
- Build badge added to README file for master